### PR TITLE
Adicionado o service para consumir projetos pelo status

### DIFF
--- a/lib/controllers/database/project_dao.dart
+++ b/lib/controllers/database/project_dao.dart
@@ -4,6 +4,7 @@ import 'package:job_timer/controllers/services/interfaces/firebase_database_serv
 import 'package:job_timer/models/constants/global_constants.dart';
 import 'package:job_timer/models/constants/project_constants.dart';
 import 'package:job_timer/models/entities/project.dart';
+import 'package:job_timer/models/entities/project_status.dart';
 
 class ProjectDAO extends IFirebaseDatabaseServices<Project> {
   final CollectionReference _db;
@@ -49,5 +50,26 @@ class ProjectDAO extends IFirebaseDatabaseServices<Project> {
     await _db.doc(data.uid).set(
           data.toMap(),
         );
+  }
+
+  @override
+  Future<List<Project>> findByStatus(
+    ProjectStatus status,
+  ) async {
+    final querySnapshot = await _db
+        .where(
+          'status',
+          isEqualTo: status.index,
+        )
+        .get();
+    List<Project> projects = [];
+
+    for (QueryDocumentSnapshot doc in querySnapshot.docs) {
+      projects.add(Project.fromMap(
+        map: doc.data() as Map<String, dynamic>,
+        uid: doc.id,
+      ));
+    }
+    return projects;
   }
 }

--- a/lib/controllers/database/project_task_dao.dart
+++ b/lib/controllers/database/project_task_dao.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:job_timer/controllers/services/interfaces/firebase_database_services.dart';
 import 'package:job_timer/models/constants/global_constants.dart';
 import 'package:job_timer/models/constants/project_tasks_constants.dart';
+import 'package:job_timer/models/entities/project_status.dart';
 import 'package:job_timer/models/entities/project_task.dart';
 
 class ProjectTaskDAO extends IFirebaseDatabaseServices<ProjectTask> {
@@ -20,9 +21,7 @@ class ProjectTaskDAO extends IFirebaseDatabaseServices<ProjectTask> {
   Future<void> create({
     required ProjectTask data,
   }) async {
-    await _db.add(data.toMap(
-      projectUid: _projectUid,
-    ));
+    await _db.add(data.toMap());
   }
 
   @override
@@ -46,7 +45,6 @@ class ProjectTaskDAO extends IFirebaseDatabaseServices<ProjectTask> {
       tasks.add(
         ProjectTask.fromMap(
           map: doc.data() as Map<String, dynamic>,
-          uid: doc.id,
         ),
       );
     }
@@ -58,9 +56,12 @@ class ProjectTaskDAO extends IFirebaseDatabaseServices<ProjectTask> {
     required ProjectTask data,
   }) async {
     await _db.doc(data.uid).set(
-          data.toMap(
-            projectUid: _projectUid,
-          ),
+          data.toMap(),
         );
+  }
+
+  @override
+  Future<List<ProjectTask>> findByStatus(ProjectStatus status) {
+    throw UnimplementedError();
   }
 }

--- a/lib/controllers/modules/home/home_module.dart
+++ b/lib/controllers/modules/home/home_module.dart
@@ -1,15 +1,22 @@
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:job_timer/controllers/modules/app_module.dart';
 import 'package:job_timer/views/pages/home/home_page.dart';
 import 'package:job_timer/views/pages/home/home_state.dart';
 
 class HomeModule extends Module {
   @override
+  List<Module> get imports => [
+        AppModule(),
+      ];
+
+    
+  @override
   void binds(Injector i) {
     super.binds(i);
-    i.addSingleton<HomeState>(
+    i.addLazySingleton<HomeState>(
       () => HomeState(
+        projectService: i.get(),
       ),
-      config: BindConfig(),
     );
   }
 

--- a/lib/controllers/repository/project_repository.dart
+++ b/lib/controllers/repository/project_repository.dart
@@ -1,6 +1,8 @@
 import 'package:job_timer/models/entities/project.dart';
+import 'package:job_timer/models/entities/project_status.dart';
 
 abstract interface class ProjectRepository {
   Future<void> register(Project project);
-  
+
+  Future<List<Project>> findByStatus(ProjectStatus status);
 }

--- a/lib/controllers/repository/project_repository_impl.dart
+++ b/lib/controllers/repository/project_repository_impl.dart
@@ -3,24 +3,30 @@ import 'dart:developer';
 import 'package:job_timer/controllers/exception/failure.dart';
 import 'package:job_timer/controllers/database/project_dao.dart';
 import 'package:job_timer/models/entities/project.dart';
+import 'package:job_timer/models/entities/project_status.dart';
 
 import './project_repository.dart';
 
 class ProjectRepositoryImpl implements ProjectRepository {
-  final ProjectDAO _projectServices;
+  final ProjectDAO _projectDAO;
 
   ProjectRepositoryImpl({required ProjectDAO projectDAO})
-      : _projectServices = projectDAO;
+      : _projectDAO = projectDAO;
 
   @override
   Future<void> register(Project project) async {
     try {
-      await _projectServices.create(
+      await _projectDAO.create(
         data: project,
       );
     } catch (e) {
       log('Erro ao criar projeto', error: e, stackTrace: StackTrace.current);
       throw Failure(message: 'Erro ao cadastrar projeto');
     }
+  }
+
+  @override
+  Future<List<Project>> findByStatus(ProjectStatus status) {
+    return _projectDAO.findByStatus(status);
   }
 }

--- a/lib/controllers/services/firebase/project/project_service.dart
+++ b/lib/controllers/services/firebase/project/project_service.dart
@@ -1,5 +1,7 @@
+import 'package:job_timer/models/entities/project_status.dart';
 import 'package:job_timer/models/models/project_model.dart';
 
 abstract interface class ProjectService {
   Future<void> register(ProjectModel project);
+  Future<List<ProjectModel>> findByStatus(ProjectStatus status);
 }

--- a/lib/controllers/services/firebase/project/project_service_impl.dart
+++ b/lib/controllers/services/firebase/project/project_service_impl.dart
@@ -1,3 +1,4 @@
+import 'package:job_timer/models/entities/project_status.dart';
 import 'package:job_timer/models/models/project_model.dart';
 import 'package:job_timer/controllers/repository/project_repository_impl.dart';
 import 'package:job_timer/models/entities/project.dart';
@@ -20,5 +21,11 @@ class ProjectServiceImpl implements ProjectService {
       uid: model.uid,
     );
     await _projectRepository.register(project);
+  }
+
+  @override
+  Future<List<ProjectModel>> findByStatus(ProjectStatus status) async {
+    final projects = await _projectRepository.findByStatus(status);
+    return projects.map((project) => ProjectModel.fromEntity(project)).toList();
   }
 }

--- a/lib/controllers/services/interfaces/firebase_database_services.dart
+++ b/lib/controllers/services/interfaces/firebase_database_services.dart
@@ -1,5 +1,8 @@
+import 'package:job_timer/models/entities/project_status.dart';
+
 abstract class IFirebaseDatabaseServices<T> {
   Future<List<T>> getAll();
+  Future<List<T>> findByStatus(ProjectStatus status);
   Future<void> delete({required String uid});
   Future<void> update({required T data});
   Future<void> create({

--- a/lib/models/entities/project.dart
+++ b/lib/models/entities/project.dart
@@ -18,13 +18,7 @@ class Project extends Equatable {
   });
 
   @override
-  List<Object?> get props => [
-        uid,
-        name,
-        status,
-        tasks,
-        estimate
-      ];
+  List<Object?> get props => [uid, name, status, tasks, estimate];
 
   factory Project.fromMap({
     required Map<String, dynamic> map,
@@ -35,14 +29,31 @@ class Project extends Equatable {
       name: map[ProjectConstants.NAME],
       status: ProjectStatus.values[map[ProjectConstants.STATUS]],
       estimate: map[ProjectConstants.ESTIMATE],
+      tasks: map[ProjectConstants.TASKS]
+          .map<ProjectTask>((task) => ProjectTask.fromMap(
+                map: task,
+              ))
+          .toList(),
     );
   }
 
   Map<String, dynamic> toMap() {
+    ProjectTask task = ProjectTask(
+      name: 'Task 1',
+      duration: 10,
+      created: DateTime.now(),
+    );
+
     return {
       ProjectConstants.NAME: name,
       ProjectConstants.STATUS: status.index,
       ProjectConstants.ESTIMATE: estimate,
+      ProjectConstants.TASKS: tasks == null
+          ? [
+              task.toMap(),
+              task.toMap(),
+            ]
+          : tasks?.map((task) => task.toMap()).toList(),
     };
   }
 }

--- a/lib/models/entities/project.dart
+++ b/lib/models/entities/project.dart
@@ -29,11 +29,13 @@ class Project extends Equatable {
       name: map[ProjectConstants.NAME],
       status: ProjectStatus.values[map[ProjectConstants.STATUS]],
       estimate: map[ProjectConstants.ESTIMATE],
-      tasks: map[ProjectConstants.TASKS]
-          .map<ProjectTask>((task) => ProjectTask.fromMap(
-                map: task,
-              ))
-          .toList(),
+      tasks: map[ProjectConstants.TASKS] != null
+          ? map[ProjectConstants.TASKS]
+              .map<ProjectTask>((task) => ProjectTask.fromMap(
+                    map: task,
+                  ))
+              .toList()
+          : [],
     );
   }
 

--- a/lib/models/entities/project_task.dart
+++ b/lib/models/entities/project_task.dart
@@ -25,23 +25,18 @@ class ProjectTask extends Equatable {
 
   factory ProjectTask.fromMap({
     required Map<String, dynamic> map,
-    required String uid,
   }) {
     return ProjectTask(
-      uid: uid,
       name: map[ProjectTasksConstants.NAME],
       duration: map[ProjectTasksConstants.DURATION],
       created: DateTime.parse(map[ProjectTasksConstants.CREATED]),
     );
   }
 
-  Map<String, dynamic> toMap({
-    required String projectUid,
-  }) {
+  Map<String, dynamic> toMap() {
     return {
       ProjectTasksConstants.NAME: name,
       ProjectTasksConstants.DURATION: duration,
-      ProjectTasksConstants.PROJECT_UID: projectUid,
       ProjectTasksConstants.CREATED: created.toIso8601String(),
     };
   }

--- a/lib/models/models/project_model.dart
+++ b/lib/models/models/project_model.dart
@@ -1,3 +1,4 @@
+import 'package:job_timer/models/entities/project.dart';
 import 'package:job_timer/models/models/project_task_model.dart';
 import 'package:job_timer/models/entities/project_status.dart';
 
@@ -16,4 +17,14 @@ class ProjectModel {
   }) : _uid = uid;
 
   String? get uid => _uid;
+
+  factory ProjectModel.fromEntity(Project project){
+    return ProjectModel(
+      uid: project.uid,
+      name: project.name,
+      status: project.status,
+      tasks: project.tasks?.map((task) => ProjectTaskModel.fromEntity(task)).toList(),
+      estimate: project.estimate,
+    );
+  }
 }

--- a/lib/models/models/project_task_model.dart
+++ b/lib/models/models/project_task_model.dart
@@ -1,3 +1,5 @@
+import 'package:job_timer/models/entities/project_task.dart';
+
 class ProjectTaskModel {
   final String? _uid;
   final String name;
@@ -10,4 +12,12 @@ class ProjectTaskModel {
   }) : _uid = uid;
 
   String? get uid => _uid;
+
+  factory ProjectTaskModel.fromEntity(ProjectTask task) {
+    return ProjectTaskModel(
+      uid: task.uid,
+      name: task.name,
+      duration: task.duration,
+    );
+  }
 }

--- a/lib/views/pages/home/home_page.dart
+++ b/lib/views/pages/home/home_page.dart
@@ -13,6 +13,12 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends AppState<HomePage, HomeState> {
   @override
+  void initState() {
+    super.initState();
+    state.initState();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       drawer: Drawer(
@@ -38,9 +44,35 @@ class _HomePageState extends AppState<HomePage, HomeState> {
               ),
             ),
             SliverPersistentHeader(
-              delegate: HeaderProjectsMenu(),
+              delegate: HeaderProjectsMenu(status: state.status),
               pinned: true,
             ),
+            SliverToBoxAdapter(
+              child: Center(
+                child: ValueListenableBuilder(
+                    valueListenable: state.isLoadingNotifier,
+                    builder: (context, isLoading, widget) {
+                      if (isLoading) {
+                        return const CircularProgressIndicator();
+                      }
+                      if (state.errorMessage != null) {
+                        return Text(state.errorMessage!);
+                      } else {
+                        return ListView.builder(
+                          shrinkWrap: true,
+                          itemCount: state.projects.length,
+                          itemBuilder: (context, index) {
+                            final project = state.projects[index];
+                            return ListTile(
+                              title: Text('Projeto: ${project.name}'),
+                              subtitle: Text('Tempo: ${project.estimate} minutos'),
+                            );
+                          },
+                        );
+                      }
+                    }),
+              ),
+            )
           ],
         ),
       ),

--- a/lib/views/pages/home/home_state.dart
+++ b/lib/views/pages/home/home_state.dart
@@ -1,9 +1,34 @@
 import 'package:flutter/cupertino.dart';
-
+import 'package:job_timer/controllers/services/firebase/project/project_service_impl.dart';
+import 'package:job_timer/models/entities/project_status.dart';
+import 'package:job_timer/models/models/project_model.dart';
 
 class HomeState extends ChangeNotifier {
+  final ProjectServiceImpl _projectService;
 
-  void createTask() async {
-   
+  HomeState({required ProjectServiceImpl projectService})
+      : _projectService = projectService;
+  final status = ValueNotifier<ProjectStatus>(ProjectStatus.em_andamento);
+
+  final isLoadingNotifier = ValueNotifier<bool>(false);
+  List<ProjectModel> projects = [];
+  String? errorMessage;
+
+  Future<void> initState() async {
+    status.addListener(() {
+      _getProjects();
+    });
+    _getProjects();
+  }
+
+  Future<void> _getProjects() async {
+    try {
+      isLoadingNotifier.value = true;
+      projects = await _projectService.findByStatus(status.value);
+      isLoadingNotifier.value = false;
+    } catch (e) {
+      errorMessage = 'Erro ao buscar projetos';
+      isLoadingNotifier.value = false;
+    }
   }
 }

--- a/lib/views/pages/home/widgets/header_projects_menu.dart
+++ b/lib/views/pages/home/widgets/header_projects_menu.dart
@@ -3,6 +3,10 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:job_timer/models/entities/project_status.dart';
 
 class HeaderProjectsMenu extends SliverPersistentHeaderDelegate {
+  ValueNotifier<ProjectStatus> status;
+  HeaderProjectsMenu({
+    required this.status,
+  });
   @override
   Widget build(
       BuildContext context, double shrinkOffset, bool overlapsContent) {
@@ -17,33 +21,41 @@ class HeaderProjectsMenu extends SliverPersistentHeaderDelegate {
             SizedBox(
               width: constraints.maxWidth * 0.4,
               child: DropdownButtonFormField<ProjectStatus>(
+                value: status.value,
                 decoration: InputDecoration(
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(20),
                   ),
+                  isDense: true, // Reduz o espaçamento interno
+                  contentPadding: const EdgeInsets.symmetric(
+                      vertical: 8, horizontal: 12), // Ajuste de padding
                 ),
-                padding: const EdgeInsets.all(10),
                 isExpanded: true,
                 items: ProjectStatus.values
                     .map((e) => DropdownMenuItem(
                           value: e,
                           child: Text(
                             e.label,
+                            softWrap: false, // Desativa quebra automática
+                            overflow: TextOverflow.ellipsis, // Adiciona "..." se cortar
                           ),
                         ))
                     .toList(),
-                onChanged: (value) {},
+                onChanged: (value) {
+                  status.value = value!;
+                },
               ),
             ),
             SizedBox(
-                width: constraints.maxWidth * 0.4,
-                child: ElevatedButton.icon(
-                  onPressed: () {
-                    Modular.to.pushNamed('/project/register/');
-                  },
-                  label: const Text('Novo Projeto'),
-                  icon: const Icon(Icons.add),
-                )),
+              width: constraints.maxWidth * 0.4,
+              child: ElevatedButton.icon(
+                onPressed: () {
+                  Modular.to.pushNamed('/project/register/');
+                },
+                label: const Text('Novo Projeto'),
+                icon: const Icon(Icons.add),
+              ),
+            ),
           ],
         ),
       );


### PR DESCRIPTION

# Descrição do Pull Request: Implementação da Listagem de Projetos

Este pull request adiciona o consumo e exibição da listagem de projetos no aplicativo, garantindo que os dados sejam carregados e exibidos na home page de forma funcional.

## Pontos Importantes

### Consumo da Listagem de Projetos

- O aplicativo consome a listagem de projetos de uma API.
- Os dados recebidos são transformados em uma classe modelo (`ProjectModel`) antes de serem convertidos em entidades (`Project`).
- **Vantagens dessa abordagem**:
  - Mantém a separação de responsabilidades.
  - Facilita a reutilização e testabilidade do código.

#### Exemplo de Código: Transformação em Model
```dart
class ProjectModel {
  final String? uid;
  final String name;
  final ProjectStatus status;
  final List<ProjectTaskModel>? tasks;
  final int estimate;

  ProjectModel({
    this.uid,
    required this.name,
    required this.status,
    this.tasks,
    required this.estimate,
  });
}
```

### Exibição na Home Page

- A listagem de projetos é exibida na página inicial do aplicativo de forma bruta (sem design finalizado).
- Cada projeto é mostrado com suas informações básicas.

### Feedback ao Usuário

- **Loading**: É exibido enquanto a listagem de projetos é carregada, impedindo múltiplas requisições.
- **Erro**: Uma mensagem de erro é exibida ao usuário caso ocorra falha no carregamento dos dados.
- **Atualização Dinâmica**: Se o status do filtro de projetos for alterado, uma nova requisição é feita para carregar os projetos correspondentes.

### Design Futuro

- O design da listagem ainda será aprimorado para melhor experiência do usuário.

## Conclusão

Esta implementação adiciona a funcionalidade de listagem de projetos ao aplicativo, incluindo carregamento dinâmico e tratamento de erros. A separação entre `Model` e `Entidade` assegura um código modular, manutenível e alinhado às boas práticas de desenvolvimento.
